### PR TITLE
catch error when user doesn't provide a prefix

### DIFF
--- a/libfulltext/fulltext.py
+++ b/libfulltext/fulltext.py
@@ -19,7 +19,11 @@ def get_fulltext(config, prefixed_identifier):
     Raises:
         ValueError: Prefix is not implemented
     """
-    prefix, identifier = prefixed_identifier.split(':', 1)
+    try:
+        prefix, identifier = prefixed_identifier.split(':', 1)
+    except ValueError:
+        raise ValueError('No prefix provided')
+
     try:
         handler = PREFIX_HANDLERS[prefix]
     except KeyError:

--- a/libfulltext/fulltext.py
+++ b/libfulltext/fulltext.py
@@ -19,11 +19,10 @@ def get_fulltext(config, prefixed_identifier):
     Raises:
         ValueError: Prefix is not implemented
     """
-    try:
-        prefix, identifier = prefixed_identifier.split(':', 1)
-    except ValueError:
+    if ":" not in prefixed_identifier:
         raise ValueError('No prefix provided')
 
+    prefix, identifier = prefixed_identifier.split(':', 1)
     try:
         handler = PREFIX_HANDLERS[prefix]
     except KeyError:

--- a/libfulltext/fulltext.py
+++ b/libfulltext/fulltext.py
@@ -17,7 +17,7 @@ def get_fulltext(config, prefixed_identifier):
                               (e.g. "doi:10.1016/j.cortex.2015.10.021")
 
     Raises:
-        ValueError: Prefix is not implemented
+        ValueError: Prefix is not implemented, of not provided by caller
     """
     if ":" not in prefixed_identifier:
         raise ValueError('No prefix provided')

--- a/libfulltext/fulltext.py
+++ b/libfulltext/fulltext.py
@@ -17,7 +17,7 @@ def get_fulltext(config, prefixed_identifier):
                               (e.g. "doi:10.1016/j.cortex.2015.10.021")
 
     Raises:
-        ValueError: Prefix is not implemented, of not provided by caller
+        ValueError: Prefix is not implemented or not provided by caller
     """
     if ":" not in prefixed_identifier:
         raise ValueError('No prefix provided')


### PR DESCRIPTION
the executable just crashed for me because I forgot the prefix. Guess there's not much we can do at that point, but there should be a clear'ish error message at least.