### PR TITLE
Raise exceptions if HTTP requests fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+fulltext
+
 ## VIM
 
 # Swap

--- a/libfulltext/doi/__init__.py
+++ b/libfulltext/doi/__init__.py
@@ -33,7 +33,9 @@ def get_doi_fulltext(doi, save_stream, config):
 
 def get_doi_registration_agency(doi):
     """Get registration agency for a DOI"""
-    ra_result = requests.get('https://doi.org/doiRA/' + doi).json()[0]
+    response = requests.get('https://doi.org/doiRA/' + doi)
+    response.raise_for_status()
+    ra_result = response.json()[0]
     if 'RA' not in ra_result:
         raise ValueError('No registration agency known for DOI {0}.'.format(doi))
     return ra_result['RA']

--- a/libfulltext/doi/crossref/__init__.py
+++ b/libfulltext/doi/crossref/__init__.py
@@ -33,4 +33,6 @@ def get_crossref_metadata(doi):
     Returns:
         dict with CrossRef metadata
     """
-    return requests.get('https://api.crossref.org/v1/works/' + doi).json()
+    response = requests.get('https://api.crossref.org/v1/works/' + doi)
+    response.raise_for_status()
+    return response.json()

--- a/libfulltext/doi/crossref/aps.py
+++ b/libfulltext/doi/crossref/aps.py
@@ -14,4 +14,6 @@ def get_aps_fulltext(doi, save_stream):
         headers={"Accept": "application/pdf"},
         stream=True
         )
+    response.raise_for_status()
+
     save_stream(response, 'fulltext.pdf')

--- a/libfulltext/doi/crossref/elsevier.py
+++ b/libfulltext/doi/crossref/elsevier.py
@@ -20,4 +20,14 @@ def get_elsevier_fulltext(doi, save_stream, apikey):
         params=params,
         stream=True
         )
+    response.raise_for_status()
+
+    # Elsevier sometimes only returns the first page (yep, also for OA content)
+    elsevier_status = response.headers['X-ELS-Status']
+    if 'WARNING' in response.headers['X-ELS-Status']:
+        raise requests.exceptions.HTTPError(
+            'X-ELS-Status indicates that request was not successful: {0}'
+            .format(elsevier_status)
+            )
+
     save_stream(response, 'fulltext.pdf')

--- a/libfulltext/doi/crossref/springer.py
+++ b/libfulltext/doi/crossref/springer.py
@@ -13,4 +13,6 @@ def get_springer_fulltext(doi, save_stream):
         'https://link.springer.com/content/pdf/{0}.pdf'.format(doi),
         stream=True
         )
+    response.raise_for_status()
+
     save_stream(response, 'fulltext.pdf')


### PR DESCRIPTION
Fixes #16 and if other requests return non-2xx-responses.

For everyone: we should call `response.raise_for_status()` everywhere to catch non-2xx responses.