### PR TITLE
Force line break in AUTHORS

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,8 +2,8 @@
 
 The authors of libfulltext are (in alphabetic order of last names)
 
-   André Gaul
-   Michael F. Herbst
-   Katrin Leinweber
-   Paul Seyfert
-   Michaela Voigt
+   André Gaul  
+   Michael F. Herbst  
+   Katrin Leinweber  
+   Paul Seyfert  
+   Michaela Voigt  


### PR DESCRIPTION
The AUTHORS.md looks nicer if we force a line break after the names.