### PR TITLE
fix click version number specification in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(name='libfulltext',
       version='1.0.0-alpha.1',
       description='Tools for downloading fulltexts of open access articles',
       url='https://github.com/andrenarchy/libfulltext',
-      install_requires=['PyYAML (>=3)', 'requests (>=2)', "click (=>5)"],
+      install_requires=['PyYAML (>=3)', 'requests (>=2)', "click (>=5)"],
       classifiers=[],
       )


### PR DESCRIPTION
 - replace "=>" by ">="
   https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies
 - this is related to #34 (otherwise `pip3 install --user .` from the local checkout fails for me)