### PR TITLE
Add coverage analysis and run flake8 in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source =
+    bin
+    libfulltext
+branch = True
+
+[report]
+show_missing = True
+omit =
+    doc/*
+    setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,14 @@ python:
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install nose2 pylint flake8
+  - travis_retry pip install codecov coverage flake8 nose2 pylint
 
 script:  # This is the 'test' build stage
-  - nose2 --with-coverage
-    # Fail if coverage below threshold
-  - python3 -m coverage report --fail-under=55 > /dev/null
+  - nose2 --with-coverage --coverage-report xml
   - pip install ${TRAVIS_BUILD_DIR}
 
 after_success:
-  - echo Success  # TODO upload coverage
+  - codecov
 
 # These jobs are only run with the first python version
 # mentioned in the initial list.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,39 @@
 # copyright © 2017 the libfulltext authors (see AUTHORS.md and LICENSE)
 
+sudo: false
 language: python
+cache: pip
 python:
-    - "3.5"
-    - "3.6"
-before_install:
-    - pip install -r requirements.txt
-    - pip install pylint nose2
-script:
-    - pylint bin libfulltext
-    - nose2
-    - pip install ${TRAVIS_BUILD_DIR}
+  - "3.5"
+  - "3.6"
+
+install:
+  - travis_retry pip install -r requirements.txt
+  - travis_retry pip install nose2 pylint flake8
+
+script:  # This is the 'test' build stage
+  - nose2 --with-coverage
+    # Fail if coverage below threshold
+  - python3 -m coverage report --fail-under=55 > /dev/null
+  - pip install ${TRAVIS_BUILD_DIR}
+
+after_success:
+  - echo Success  # TODO upload coverage
+
+# These jobs are only run with the first python version
+# mentioned in the initial list.
+jobs:
+  include:
+    - stage: code style
+      script: pylint bin libfulltext
+    - script: flake8
+    #
+    - stage: deploy
+      # TODO deploy to pip
+      script: skip
+
+stages:
+  - code style
+  - test
+  - name: deploy
+    if: branch = master AND type = push

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ jobs:
   include:
     - stage: code style
       script: pylint bin libfulltext
+      env: CODE_STYLE="pylint"
     - script: flake8
+      env: CODE_STYLE="flake8"
     #
     - stage: deploy
       # TODO deploy to pip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # libfulltext
 [![Build Status](https://travis-ci.org/andrenarchy/libfulltext.svg?branch=master)](https://travis-ci.org/andrenarchy/libfulltext)
+[![codecov](https://codecov.io/gh/andrenarchy/libfulltext/branch/master/graph/badge.svg)](https://codecov.io/gh/andrenarchy/libfulltext)
 [![Licence: GPL v3](https://img.shields.io/github/license/andrenarchy/libfulltext.svg)](LICENSE)
 
 libfulltext is a python suite to aid with bulk-downloading open-access papers.

--- a/libfulltext/__init__.py
+++ b/libfulltext/__init__.py
@@ -2,3 +2,4 @@
 """libfulltext module"""
 
 from .fulltext import get_fulltext
+__all__ = ["get_fulltext"]

--- a/libfulltext/doi/crossref/aps.py
+++ b/libfulltext/doi/crossref/aps.py
@@ -2,8 +2,8 @@
 """American Physical Society publisher module"""
 
 import requests
-
 from ...response import verify
+
 
 def get_aps_fulltext(doi, save_stream):
     """Retrieve APS fulltext
@@ -16,8 +16,7 @@ def get_aps_fulltext(doi, save_stream):
         'http://harvest.aps.org/v2/journals/articles/{0}'.format(doi),
         headers={"Accept": "application/pdf"},
         stream=True
-        )
+    )
 
     verify(response, 'application/pdf')
-
     save_stream(response, 'fulltext.pdf')

--- a/libfulltext/doi/crossref/elsevier.py
+++ b/libfulltext/doi/crossref/elsevier.py
@@ -2,8 +2,8 @@
 """Elsevier publisher module"""
 
 import requests
-
 from ...response import verify
+
 
 def get_elsevier_fulltext(doi, save_stream, apikey):
     """Retrieve Elsevier fulltext
@@ -25,7 +25,7 @@ def get_elsevier_fulltext(doi, save_stream, apikey):
         'https://api.elsevier.com/content/article/doi/' + doi,
         params=params,
         stream=True
-        )
+    )
 
     verify(response, 'application/pdf')
 
@@ -35,6 +35,6 @@ def get_elsevier_fulltext(doi, save_stream, apikey):
         raise requests.exceptions.HTTPError(
             'X-ELS-Status indicates that request was not successful: {0}'
             .format(elsevier_status)
-            )
+        )
 
     save_stream(response, 'fulltext.pdf')

--- a/libfulltext/doi/crossref/springer.py
+++ b/libfulltext/doi/crossref/springer.py
@@ -2,8 +2,8 @@
 """SpringerNature publisher module"""
 
 import requests
-
 from ...response import verify
+
 
 def get_springer_fulltext(doi, save_stream):
     """Retrieve SpringerNature fulltext
@@ -15,8 +15,7 @@ def get_springer_fulltext(doi, save_stream):
     response = requests.get(
         'https://link.springer.com/content/pdf/{0}.pdf'.format(doi),
         stream=True
-        )
+    )
 
     verify(response, 'application/pdf')
-
     save_stream(response, 'fulltext.pdf')

--- a/libfulltext/doi/crossref/test_aps.py
+++ b/libfulltext/doi/crossref/test_aps.py
@@ -7,6 +7,7 @@ import requests
 from ...response import assert_sha1
 from .aps import get_aps_fulltext
 
+
 class GetApsFulltextTest(TestCase):
     """Test get_aps_fulltext"""
 
@@ -16,7 +17,7 @@ class GetApsFulltextTest(TestCase):
         get_aps_fulltext(
             '10.1103/PhysRevPhysEducRes.13.020141',
             assert_sha1('4a1b37cf8dc7699d01b744a1f6da8fbcba8e3b6d', 'fulltext.pdf')
-            )
+        )
 
     def test_no_access(self):
         """No access should be detected."""
@@ -24,7 +25,7 @@ class GetApsFulltextTest(TestCase):
             get_aps_fulltext(
                 '10.1103/PhysRevA.96.063419',
                 lambda stream, filename: None,
-                )
+            )
         self.assertIn('Unauthorized', str(context.exception))
 
     def test_non_existent_doi(self):

--- a/libfulltext/doi/crossref/test_elsevier.py
+++ b/libfulltext/doi/crossref/test_elsevier.py
@@ -7,6 +7,7 @@ import requests
 from ...response import assert_sha1
 from .elsevier import get_elsevier_fulltext
 
+
 class GetElsevierFulltextTest(TestCase):
     """Test get_elsevier_fulltext"""
 
@@ -19,7 +20,7 @@ class GetElsevierFulltextTest(TestCase):
             '10.1016/j.physletb.2016.07.042',
             assert_sha1('4724fea61643131e32dd4267608f977ffeafb70e', 'fulltext.pdf'),
             apikey='f7840794d3322d4b56a9cf687aecfccb'
-            )
+        )
 
     def test_incomplete_pdf(self):
         """An incomplete PDF (restricted to first page) should be detected.
@@ -29,7 +30,7 @@ class GetElsevierFulltextTest(TestCase):
                 '10.1016/j.laa.2017.12.020',
                 lambda stream, filename: None,
                 apikey='f7840794d3322d4b56a9cf687aecfccb'
-                )
+            )
         self.assertIn('Response limited to first page', str(context.exception))
 
     def test_non_existent_doi(self):
@@ -39,5 +40,5 @@ class GetElsevierFulltextTest(TestCase):
                 '10.1103/non-existent',
                 lambda stream, filename: None,
                 apikey='f7840794d3322d4b56a9cf687aecfccb'
-                )
+            )
         self.assertIn('Not Found', str(context.exception))

--- a/libfulltext/doi/crossref/test_springer.py
+++ b/libfulltext/doi/crossref/test_springer.py
@@ -7,6 +7,7 @@ import requests
 from ...response import assert_sha1
 from .springer import get_springer_fulltext
 
+
 class GetSpringerFulltextTest(TestCase):
     """Test get_springer_fulltext"""
 
@@ -16,7 +17,7 @@ class GetSpringerFulltextTest(TestCase):
         get_springer_fulltext(
             '10.1140/epjc/s10052-016-4338-8',
             assert_sha1('4d188155b7d395356d6f62794f41cc6d083296b0', 'fulltext.pdf')
-            )
+        )
 
     def test_no_access(self):
         """No access should be detected."""
@@ -24,11 +25,12 @@ class GetSpringerFulltextTest(TestCase):
             get_springer_fulltext(
                 '10.1007/978-3-658-06610-9',
                 lambda stream, filename: None,
-                )
+            )
         self.assertIn('you do not have access', str(context.exception))
 
     def test_non_existent_doi(self):
         """A non-existing DOI should result in an error"""
         with self.assertRaises(requests.exceptions.HTTPError) as context:
-            get_springer_fulltext('10.1140/epjc/non-existent', lambda stream, filename: None)
+            get_springer_fulltext('10.1140/epjc/non-existent',
+                                  lambda stream, filename: None)
         self.assertIn('Not Found', str(context.exception))

--- a/libfulltext/response.py
+++ b/libfulltext/response.py
@@ -17,7 +17,6 @@ def assert_sha1(expected_sha1, expected_path):
         (basename where the stream should usually be saved). This function
         matches the interface of save_stream.
     """
-
     def process_response(response, path):
         """Process a response and verify SHA1 hash and path
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@
 [flake8]
 ignore = E241,E266
 max-line-length = 90
+include = bin libfulltext
 exclude =
     .git
     __pycache__
     doc
-    __init__.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,8 @@
 [flake8]
 ignore = E241,E266
 max-line-length = 90
+exclude =
+    .git
+    __pycache__
+    doc
+    __init__.py


### PR DESCRIPTION
This PR adds coverage analysis to `libfulltext` and checks for PEP8 conformity with `flake8`.

Right now I only use `nose` to do the coverage analysis and check it is above 55%, but ideally we should track it using coveralls or codecov and display a nice badge. Of course we should get the coverage higher as well.

@andrenarchy Could you maybe do the relevant setup for codecov or coveralls in the repository settings?
  