### PR TITLE
install executable and submodules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,20 @@
 # with distutils).  For normal builds use distutils.
 try:
     from setuptools import setup
+    from setuptools import find_packages
 except ImportError:
     from distutils.core import setup
 
+    def find_packages(*args, **kwargs):
+        return ['libfulltext.doi']
+
+
 setup(name='libfulltext',
-      packages=['libfulltext'],
+      packages=find_packages(),
       version='1.0.0-alpha.1',
       description='Tools for downloading fulltexts of open access articles',
       url='https://github.com/andrenarchy/libfulltext',
       install_requires=['PyYAML (>=3)', 'requests (>=2)', "click (>=5)"],
+      scripts=['bin/get_fulltext.py'],
       classifiers=[],
       )


### PR DESCRIPTION
In case the installation uses distutils, a hard coded list of
submodules is used. The list of executables is hard coded as well.

This fixes #50.

We might want to add tests for the hard coded lists.